### PR TITLE
Send scroll event even when *final* scroll position is unchanged.

### DIFF
--- a/vaadin-scrollable-panel/pom.xml
+++ b/vaadin-scrollable-panel/pom.xml
@@ -4,7 +4,7 @@
 	<groupId>org.vaadin.addons</groupId>
 	<artifactId>vaadin-scrollable-panel</artifactId>
 	<packaging>jar</packaging>
-	<version>1.0.3-SNAPSHOT</version>
+	<version>1.0.4</version>
 	<name>ScrollablePanel Add-on</name>
 	<description>A panel with ability to read and write the scroll position of the content</description>
 	<url>https://github.com/bonprix/vaadin-scrollable-panel</url>

--- a/vaadin-scrollable-panel/src/main/java/org/vaadin/addons/scrollablepanel/ScrollablePanel.java
+++ b/vaadin-scrollable-panel/src/main/java/org/vaadin/addons/scrollablepanel/ScrollablePanel.java
@@ -174,6 +174,23 @@ public class ScrollablePanel extends AbstractSingleComponentContainer {
 		getState().scrollEventDelayMillis = millis;
 	}
 
+
+	/**
+	 * If true an event will be sent even when scroll position
+	 * was changed and returned to initial position within scrollEventDelay.
+	 */
+	public boolean isSendScrollPosWhenUnchanged() {
+		return getState().sendScrollPosWhenUnchanged;
+	}
+
+	/**
+	 * Sets whether an event should be sent even when scroll position
+	 * was changed and returned to initial position within scrollEventDelay.
+	 */
+	public void setSendScrollPosWhenUnchanged(boolean sendScrollPosWhenUnchanged) {
+		getState().sendScrollPosWhenUnchanged = sendScrollPosWhenUnchanged;
+	}
+
 	// Listener
 	@SuppressWarnings("serial")
 	private final ScrollablePanelServerRpc rpc = new ScrollablePanelServerRpc() {

--- a/vaadin-scrollable-panel/src/main/java/org/vaadin/addons/scrollablepanel/client/ScrollablePanelState.java
+++ b/vaadin-scrollable-panel/src/main/java/org/vaadin/addons/scrollablepanel/client/ScrollablePanelState.java
@@ -13,6 +13,7 @@ public class ScrollablePanelState extends AbstractComponentState {
 	public int scrollEventDelayMillis;
 	public boolean horizontalScrollingEnabled = true;
 	public boolean verticalScrollingEnabled = true;
+	public boolean sendScrollPosWhenUnchanged = false;
 
 	public int scrollTop = 0;
 	public int scrollLeft = 0;

--- a/vaadin-scrollable-panel/src/main/java/org/vaadin/addons/scrollablepanel/client/ScrollablePanelWidget.java
+++ b/vaadin-scrollable-panel/src/main/java/org/vaadin/addons/scrollablepanel/client/ScrollablePanelWidget.java
@@ -19,6 +19,7 @@ public class ScrollablePanelWidget extends ScrollPanel {
 
 	private boolean horizontalScrollingEnabled = true;
 	private boolean verticalScrollingEnabled = true;
+	private boolean sendScrollPosWhenUnchanged = false;
 
 	public ScrollablePanelWidget() {
 		super();
@@ -51,10 +52,8 @@ public class ScrollablePanelWidget extends ScrollPanel {
 			this.executor = new VLazyExecutor(this.scrollEventDelayMillis, new ScheduledCommand() {
 				@Override
 				public void execute() {
-					if (ScrollablePanelWidget.this.timedHandler != null
-					        && ScrollablePanelWidget.this.currentScrollingPos != null
-					        && (ScrollablePanelWidget.this.lastSentScrollPos == null || !ScrollablePanelWidget.this.currentScrollingPos
-					                .equals(ScrollablePanelWidget.this.lastSentScrollPos))) {
+                    if (timedHandler != null && currentScrollingPos != null
+                            && (sendScrollPosWhenUnchanged || !currentScrollingPos.equals(lastSentScrollPos))) {
 						ScrollablePanelWidget.this.timedHandler.onScroll(ScrollablePanelWidget.this.currentScrollingPos);
 						ScrollablePanelWidget.this.lastSentScrollPos = ScrollablePanelWidget.this.currentScrollingPos;
 					}
@@ -95,4 +94,11 @@ public class ScrollablePanelWidget extends ScrollPanel {
 		this.verticalScrollingEnabled = verticalScrollingEnabled;
 	}
 
+    public boolean isSendScrollPosWhenUnchanged() {
+        return sendScrollPosWhenUnchanged;
+    }
+
+    public void setSendScrollPosWhenUnchanged(boolean sendScrollPosWhenUnchanged) {
+        this.sendScrollPosWhenUnchanged = sendScrollPosWhenUnchanged;
+    }
 }


### PR DESCRIPTION
Hi!
I'm using your addon and it works well. But I have the following usecase:
Whenever user scrolls up to the top of the component, it content should be refreshed.
But when he/she is on top (scrollPos = 0) and quickly scroll down and up that in the end scrollPos = 0 again. Then no event is sent and view is not refreshed. (User has to do it within event delay)

I added configuration that allows to send an event in above condition.
I hope you'll like it. 
Please let me know whether it is possible to release new version with this changes.